### PR TITLE
Add topic name functionality

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -6,10 +6,12 @@ Even if you only want to compile code for your machine, Matlab comes with its ow
 
 ## Using ROS Groovy
 
+Install the [rosinstall_generator](http://wiki.ros.org/rosinstall_generator#Installation) package for ROS.
+
 Generate install file and download necessary packages
 
     mkdir ~/matbag_ws && cd ~/matbag_ws
-    wget http://packages.ros.org/web/rosinstall/generate/raw/groovy/rosbag -O base.rosinstall
+    rosinstall_generator rosbag --deps > base.rosinstall
     rosinstall --catkin -n src base.rosinstall
     rm src/CMakeLists.txt
     src/catkin/bin/catkin_init_workspace src
@@ -23,14 +25,21 @@ Modify src/CMakeLists.txt so that the lines after cmake_minimum_required() are:
 
 By compiling out logging with ROSCONSOLE_SEVERITY_NONE, we don't need to build log4cxx or any of its dependencies.  Now build the ROS libraries.
 
-    ./catkin/bin/catkin_make
+    .src/catkin/bin/catkin_make
 
-All of the libraries should now be in <tt>matbag_ws/install/lib</tt>
+Now copy all of the libraries to <tt>matbag_ws/install/lib</tt>
+
+    cp devel/lib/* ~/matbag_ws/install/lib/
+
 
 ### [Boost](http://www.boost.org/users/download/)
 
     ./bjam cxxflags='-fPIC'  --build-dir=mybuild --with-regex --with-system \
       --stagedir=$HOME/matab_ws/install/ link=static stage
+
+Now copy all of the libraries to <tt>matbag_ws/install/lib</tt>
+
+    cp stage/lib/* ~/matbag_ws/install/lib/
 
 ### [bz2](http://www.bzip.org/downloads.html)
 
@@ -45,7 +54,7 @@ Clone the repository and use the <tt>mex_compile.sh</tt> build script
     git clone git://github.com/bcharrow/matlab_rosbag.git
     cd matlab_rosbag/src
     bash mex_compile.sh
-    
+
 
 ## Using ROS Electric
 
@@ -66,8 +75,8 @@ where LIB_DIR is a directory where you will put all of the static libraries.
 
     ./bootstrap.sh
     ./bjam cxxflags='-fPIC'  --build-dir=mybuild \
-        --with-regex --with-thread --with-signals --with-filesystem \  
-        --with-system link=static stag
+        --with-regex --with-thread --with-signals --with-filesystem \
+        --with-system link=static stage
      cp stage/lib/* LIB_DIR
 
 ### [bz2](http://www.bzip.org/downloads.html)
@@ -96,16 +105,16 @@ IMPORTANT: On OS X I had to compile the APR implementation of iconv() and compil
 
 ### [APR-util](http://apr.apache.org/download.cgi)
 
-    CFLAGS=-fPIC ./configure \ 
-                 --with-iconv=../apr-iconv-1.2.1/install \ 
-                 --with-apr=../apr-1.4.6/install \                   
+    CFLAGS=-fPIC ./configure \
+                 --with-iconv=../apr-iconv-1.2.1/install \
+                 --with-apr=../apr-1.4.6/install \
                  --with-expat=../expat-2.1.0/install
     make
     cp .libs/libapr-1.a LIB_DIR
 
 ### [log4cxx](http://logging.apache.org/log4cxx/download.html)
 
-    CFLAGS=-fPIC ./configure --prefix=$(pwd)/install \ 
+    CFLAGS=-fPIC ./configure --prefix=$(pwd)/install \
         --with-apr=../apr-1.4.6/install \
         --with-apr-util=../apr-util-1.5.1/install
     make

--- a/src/+ros/Bag.m
+++ b/src/+ros/Bag.m
@@ -127,5 +127,15 @@ classdef Bag
         % [type] = topics(topic)
             type = rosbag_wrapper(obj.handle, 'topicType', topic);
         end
+
+        function [topic, types] = topics(obj)
+        % Get a cell array listing all topics in bag and their types.
+        % [topic, types] = topics()
+            topic = rosbag_wrapper(obj.handle, 'topics');
+            if nargout > 1
+                types = rosbag_wrapper(obj.handle, 'topicType', topic);
+            end
+        end
+
     end
 end

--- a/src/+ros/Bag.m
+++ b/src/+ros/Bag.m
@@ -121,5 +121,11 @@ classdef Bag
         function [out] = disp(obj)
             fprintf('ros.Bag(''%s'')\n\n', obj.path);
         end
+
+        function [type] = topicType(obj, topic)
+        % Get a string listing the message type of topic or topics
+        % [type] = topics(topic)
+            type = rosbag_wrapper(obj.handle, 'topicType', topic);
+        end
     end
 end

--- a/src/+ros/Bag.m
+++ b/src/+ros/Bag.m
@@ -128,10 +128,14 @@ classdef Bag
             type = rosbag_wrapper(obj.handle, 'topicType', topic);
         end
 
-        function [topic, types] = topics(obj)
+        function [topic, types] = topics(obj, regex)
         % Get a cell array listing all topics in bag and their types.
-        % [topic, types] = topics()
-            topic = rosbag_wrapper(obj.handle, 'topics');
+        % Optionally, use regular expression regex to select topics.
+        % [topic, types] = topics(regex)
+            if nargin < 2
+                regex = '.*';
+            end
+            topic = rosbag_wrapper(obj.handle, 'topics', regex);
             if nargout > 1
                 types = rosbag_wrapper(obj.handle, 'topicType', topic);
             end

--- a/src/matlab_util.hpp
+++ b/src/matlab_util.hpp
@@ -97,6 +97,22 @@ mxArray* mexWrap<std::string>(const std::string& value) {
   return mxCreateString(value.c_str());
 }
 
+// specialization for std::vector<std::string>.
+// wrap into a cell array of strings if vector has more than one element,
+// else wrap into a character array
+template<>
+mxArray* mexWrap<std::vector<std::string> >(const std::vector<std::string> &s) {
+  if (s.size() == 1) {
+    return mxCreateString(s[0].c_str());
+  } else {
+    mxArray *strings = mxCreateCellMatrix(1, s.size());
+    for (int i = 0; i < s.size(); ++i) {
+      mxSetCell(strings, i, mxCreateString(s[i].c_str()));
+    }
+    return strings;
+  }
+}
+
 // specialization to char
 template<>
 mxArray* mexWrap<char>(const char& value) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -651,6 +651,9 @@ void BagInfo::readTypeMaps(const vector<const rosbag::ConnectionInfo*> &connecti
         throw;
       }
     }
+    if (topic_types_.find(ci->topic) == topic_types_.end()) {
+      topic_types_[ci->topic] = ci->datatype;
+    }
   }
 }
 
@@ -743,6 +746,34 @@ string BagInfo::definition(const std::string &msg_type) const {
     }
     throw invalid_argument("Couldn't find message definition");
   }
+}
+
+bool BagInfo::isTopic(const string &topic) const {
+  map<string, string>::const_iterator it = topic_types_.find(topic);
+  if (it != topic_types_.end()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+string BagInfo::topicType(const string &topic) const {
+  map<string, string>::const_iterator it = topic_types_.find(topic);
+  if (it != topic_types_.end()) {
+    return it->second;
+  } else {
+    throw invalid_argument("Couldn't find topic '" + topic + "'");
+  }
+}
+
+vector<string> BagInfo::topicType(const vector<string> &topics) const {
+  vector<string> types(topics.size());
+  vector<string>::const_iterator it;
+  int i = 0;
+  for (it = topics.begin(), i = 0; it != topics.end(); ++it, ++i) {
+    types[i] = topicType(*it);
+  }
+  return types;
 }
 
 //============================= msg_definition ==============================//

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -786,6 +786,16 @@ vector<string> BagInfo::topicType(const vector<string> &topics) const {
   return types;
 }
 
+vector<string> BagInfo::topics(void) const {
+  vector<string> topic_vec(topic_types_.size());
+  map<string, string>::const_iterator it;
+  int i;
+  for (it = topic_types_.begin(), i = 0; it != topic_types_.end(); ++it, ++i) {
+    topic_vec[i] = it->first;
+  }
+  return topic_vec;
+}
+
 //============================= msg_definition ==============================//
 
 void msg_definition_helper(const ROSMessageFields *rmf, const ROSTypeMap &rtm,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -786,12 +786,14 @@ vector<string> BagInfo::topicType(const vector<string> &topics) const {
   return types;
 }
 
-vector<string> BagInfo::topics(void) const {
-  vector<string> topic_vec(topic_types_.size());
+vector<string> BagInfo::topics(const string &regexp) const {
+  const boost::regex reg(regexp);
+  vector<string> topic_vec;
   map<string, string>::const_iterator it;
-  int i;
-  for (it = topic_types_.begin(), i = 0; it != topic_types_.end(); ++it, ++i) {
-    topic_vec[i] = it->first;
+  for (it = topic_types_.begin(); it != topic_types_.end(); ++it) {
+    if (boost::regex_match(it->first, reg)) {
+      topic_vec.push_back(it->first);
+    }
   }
   return topic_vec;
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -108,6 +108,12 @@ public:
   std::string rawDefinition(const std::string &msg_type) const;
   std::string definition(const std::string &msg_type) const;
 
+  // Check if string a topic name
+  bool isTopic(const std::string &topic) const;
+  // Get a string listing the type of message published on a topic
+  std::string topicType(const std::string &topic) const;
+  std::vector<std::string> topicType(const std::vector<std::string> &topic) const;
+
 private:
   struct TopicSummary {
     std::string topic;
@@ -130,6 +136,8 @@ private:
   // qualified names and unqualified names.
   std::map<std::string, std::string> msg_defs_;
   std::map<std::string, ROSTypeMap*> type_maps_;
+  // Map from topic names to message type.
+  std::map<std::string, std::string> topic_types_;
 };
 
 // Get a string which describes the message (basically "rosmsg show")

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -113,6 +113,8 @@ public:
   // Get a string listing the type of message published on a topic
   std::string topicType(const std::string &topic) const;
   std::vector<std::string> topicType(const std::vector<std::string> &topic) const;
+  // Return vector containing all topics in bag
+  std::vector<std::string> topics(void) const;
 
 private:
   struct TopicSummary {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -105,9 +105,9 @@ public:
   // Get a string summarizing the contents of the bag.  Outputs most of the
   // information found in "rosbag info"
   std::string info();
-  std::string rawDefinition(const std::string &msg_type) const;
-  std::string definition(const std::string &msg_type) const;
-
+  // Check if input string is a topic name or message type.  Outputs the
+  // definition of the resolved message type.
+  std::string definition(const std::string &input, bool raw) const;
   // Check if string a topic name
   bool isTopic(const std::string &topic) const;
   // Get a string listing the type of message published on a topic

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -113,8 +113,9 @@ public:
   // Get a string listing the type of message published on a topic
   std::string topicType(const std::string &topic) const;
   std::vector<std::string> topicType(const std::vector<std::string> &topic) const;
-  // Return vector containing all topics in bag
-  std::vector<std::string> topics(void) const;
+  // Return vector containing all topics in bag matching regular
+  // expression regexp.
+  std::vector<std::string> topics(const std::string &regexp) const;
 
 private:
   struct TopicSummary {

--- a/src/rosbag_wrapper.cpp
+++ b/src/rosbag_wrapper.cpp
@@ -367,10 +367,11 @@ public:
       vector<string> topics = mexUnwrap<vector<string> >(prhs[1]);
       plhs[0] = mexWrap<vector<string> >(info_.topicType(topics));
     } else if (cmd == "topics") {
-      if (nrhs != 1) {
-        error("ROSBagWrapper::mex() Expected zero arguments");
+      if (nrhs != 2) {
+        error("ROSBagWrapper::mex() Expected one argument");
       }
-      vector<string> topics = info_.topics();
+      string regexp = mexUnwrap<string>(prhs[1]);
+      vector<string> topics = info_.topics(regexp);
       plhs[0] = mexWrap<vector<string> >(topics);
     } else {
       throw invalid_argument("ROSBagWrapper::mex() Unknown method");

--- a/src/rosbag_wrapper.cpp
+++ b/src/rosbag_wrapper.cpp
@@ -366,6 +366,12 @@ public:
       }
       vector<string> topics = mexUnwrap<vector<string> >(prhs[1]);
       plhs[0] = mexWrap<vector<string> >(info_.topicType(topics));
+    } else if (cmd == "topics") {
+      if (nrhs != 1) {
+        error("ROSBagWrapper::mex() Expected zero arguments");
+      }
+      vector<string> topics = info_.topics();
+      plhs[0] = mexWrap<vector<string> >(topics);
     } else {
       throw invalid_argument("ROSBagWrapper::mex() Unknown method");
     }

--- a/src/rosbag_wrapper.cpp
+++ b/src/rosbag_wrapper.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 
 // Specialization for ros::Time.
-// Return a struct with integer 'sec', 'nsec', fields and a doulbe 'time' field.
+// Return a struct with integer 'sec', 'nsec', fields and a double 'time' field.
 template<>
 mxArray* mexWrap<ros::Time>(const ros::Time &t) {
   const char *fields[] = {"sec", "nsec", "time"};
@@ -364,6 +364,12 @@ public:
       } else {
         plhs[0] = mexWrap<string>(info_.definition(msg_type));
       }
+    } else if (cmd == "topicType") {
+      if (nrhs != 2) {
+        error("ROSBagWrapper::mex() Expected one argument");
+      }
+      vector<string> topics = mexUnwrap<vector<string> >(prhs[1]);
+      plhs[0] = mexWrap<vector<string> >(info_.topicType(topics));
     } else {
       throw invalid_argument("ROSBagWrapper::mex() Unknown method");
     }

--- a/src/rosbag_wrapper.cpp
+++ b/src/rosbag_wrapper.cpp
@@ -359,11 +359,7 @@ public:
       }
       string msg_type = mexUnwrap<string>(prhs[1]);
       bool raw = mexUnwrap<bool>(prhs[2]);
-      if (raw) {
-        plhs[0] = mexWrap<string>(info_.rawDefinition(msg_type));
-      } else {
-        plhs[0] = mexWrap<string>(info_.definition(msg_type));
-      }
+      plhs[0] = mexWrap<string>(info_.definition(msg_type, raw));
     } else if (cmd == "topicType") {
       if (nrhs != 2) {
         error("ROSBagWrapper::mex() Expected one argument");


### PR DESCRIPTION
I added two functions to the Matlab Bag class:
- topics returns a list of topics in a bag and the message type of each topic and takes an optional input regular expression to match topic names.
- topicType returns the message types that are being published on the input topics.

I updated the definition method so that now it accepts as input either a message type or a topic name.
I updated the instructions in COMPILING.md to use rosinstall_generator.
