### PR TITLE
mex_compile_ros: Compile using existing system libraries

### DIFF
--- a/src/mex_compile_ros.sh
+++ b/src/mex_compile_ros.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+INCLUDE="$(pkg-config --cflags eigen3) $(pkg-config --cflags cpp_common)"
+LINK="$(pkg-config --libs-only-L cpp_common)"
+if [[ $(uname -s) == "Linux" ]]; then
+    LINK="${LINK} -lrt"
+fi
+
+mex -O rosbag_wrapper.cpp parser.cpp \
+    -lrosbag_storage \
+    -lcpp_common \
+    -lrostime \
+    -lconsole_bridge \
+    -ltf2 \
+    -lroscpp_serialization \
+    -lboost_regex \
+    -lboost_signals \
+    -lboost_system \
+    -lbz2 \
+    ${INCLUDE} ${LINK}


### PR DESCRIPTION
For system with 64-bit MATLAB, you can try out compiling the MEX files using existing system libraries. I was able to compile in this fashion and run the example on Ubuntu 12.04 with Matlab R2013a (Student Edition). (This is after having replaced MATLAB's copies of `libstdc++*`)

Of course, users run the risk of random errors given the different library versions, but this is for the impatient risk takers :P
